### PR TITLE
Fix: fail the CI if flake8 fails

### DIFF
--- a/dorpsgek_irc/watcher_commands/notify/push.py
+++ b/dorpsgek_irc/watcher_commands/notify/push.py
@@ -21,7 +21,7 @@ async def push(event, ws, irc):
         irc.privmsg(channel,
                     f"[{event.data['repository_name']}] "
                     f"{event.data['user']} pushed {commit_count} commits to {event.data['branch']}:"
-        )
+                    )
         for commit in event.data["commits"]:
             irc.privmsg(channel, f"  - {commit['message']} (by {commit['author']})")
         irc.privmsg(channel, event.data["url"])

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 echo "Running flake8 ..."
 flake8 dorpsgek_irc
 


### PR DESCRIPTION
Without 'set -e', an non-zero exit code from flake8 is simply
ignored and test.sh continues. With 'set -e' it abort on the
first non-zero exit code.